### PR TITLE
Update Executor interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Build
         run: MINILOOP_TASK_ARRAY_SIZE=256 cargo build --all-targets
       - name: Run tests
-        run: cargo test
+        run: MINILOOP_TASK_ARRAY_SIZE=256 cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,6 @@ jobs:
         with:
           toolchain: stable
       - name: Build
-        run: cargo build --all-targets
+        run: MINILOOP_TASK_ARRAY_SIZE=256 cargo build --all-targets
       - name: Run tests
         run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniloop"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 resolver = "2"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ exclude = [
 
 [[example]]
 name = "simple"
+
+[[example]]
+name = "simple2"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,8 @@
+//! This example requires to be built with environment variable set `MINILOOP_TASK_ARRAY_SIZE=4`
+//! since it creates 4 tasks for execution
 use miniloop::executor::Executor;
 use miniloop::helpers::yield_me;
+use miniloop::task::Task;
 
 fn sleep(s: u64) {
     std::thread::sleep(std::time::Duration::from_secs(s));
@@ -34,24 +37,32 @@ fn main() {
     let mut executor = Executor::new();
     executor.set_pending_callback(pending_print);
 
-    let mut binding1 = async {
+    let mut task1 = Task::new("hello", async {
         dummy_func("hello").await;
-    };
-    let mut binding2 = async {
+    });
+    let mut handle1 = task1.create_handle();
+    let mut task2 = Task::new("world", async {
         dummy_func("world").await;
-    };
-    let mut binding3 = async {
+    });
+    let mut handle2 = task2.create_handle();
+    let mut task3 = Task::new("hi", async {
         dummy_func("hi").await;
-    };
-    let mut binding4 = async {
+    });
+    let mut handle3 = task3.create_handle();
+    let mut task4 = Task::new("rust", async {
         dummy_func("rust").await;
-    };
+    });
+    let mut handle4 = task4.create_handle();
 
-    let _ = executor.spawn("hello", &mut binding1);
-    let _ = executor.spawn("world", &mut binding2);
-    let _ = executor.spawn("hi", &mut binding3);
-    let _ = executor.spawn("rust", &mut binding4);
+    let _ = executor.spawn(&mut task1, &mut handle1);
+    let _ = executor.spawn(&mut task2, &mut handle2);
+    let _ = executor.spawn(&mut task3, &mut handle3);
+    let _ = executor.spawn(&mut task4, &mut handle4);
 
     executor.run();
     println!("Done!");
+    assert!(handle1.value.is_some());
+    assert!(handle2.value.is_some());
+    assert!(handle3.value.is_some());
+    assert!(handle4.value.is_some());
 }

--- a/examples/simple2.rs
+++ b/examples/simple2.rs
@@ -1,10 +1,8 @@
-use core::fmt::Debug;
-use core::future::Future;
-use core::pin::Pin;
-use core::task::{ready, Context, Poll};
 use miniloop::executor::Executor;
 use miniloop::helpers::yield_me;
-use std::time::Duration;
+use miniloop::task::Task;
+
+use core::time::Duration;
 
 fn is_expired(start: u64, delay_s: u64) -> bool {
     get_timestamp_sec() - start < delay_s
@@ -48,72 +46,18 @@ fn pending_print(task_name: &str) {
     println!("{now}: Task {task_name} is pending. Waiting for the next tick...");
 }
 
-struct Runner<'a, T: Future> {
-    future: T,
-    handle: Option<&'a mut Handle<T::Output>>,
-}
-
-impl<'a, T: Future> Runner<'a, T> {
-    fn new(future: T) -> (Self, Handle<T::Output>) {
-        let handle = Handle { val: None };
-        let runner = Self {
-            future,
-            handle: None,
-        };
-
-        (runner, handle)
-    }
-
-    fn link_handle(&mut self, handle: &'a mut Handle<T::Output>) {
-        self.handle = Some(handle);
-    }
-}
-
-impl<T: Future> Future for Runner<'_, T>
-where
-    T::Output: Debug,
-{
-    type Output = ();
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = unsafe { self.get_unchecked_mut() };
-        // SAFETY:
-        // 1. `this.future` is never moved out of `Runner` after this line.
-        // 2. `this.future` is not used to create a `Pin<&mut T>` anywhere else.
-        let future = unsafe { Pin::new_unchecked(&mut this.future) };
-        let res = ready!(future.poll(cx));
-
-        if let Some(handle) = this.handle.as_mut() {
-            handle.val = Some(res);
-        }
-
-        Poll::Ready(())
-    }
-}
-
-struct Handle<T> {
-    val: Option<T>,
-}
-
-macro_rules! bind {
-    ($e:expr) => {{
-        let _binding = async { $e().await };
-        _binding
-    }};
-}
-
 fn main() {
     let mut executor = Executor::new();
     executor.set_pending_callback(pending_print);
+    let mut task1 = Task::new("foo", foo());
+    let mut handle1 = task1.create_handle();
+    let mut task2 = Task::new("bar", async { bar().await });
+    let mut handle2 = task2.create_handle();
 
-    let (mut runner1, mut handle1) = Runner::new(async { foo().await });
-    runner1.link_handle(&mut handle1);
-    let _ = executor.spawn("foo", &mut runner1);
-    let (mut runner2, mut handle2) = Runner::new(async move { bar().await });
-    runner2.link_handle(&mut handle2);
-    let _ = executor.spawn("bar", &mut runner2);
-
+    let _ = executor.spawn(&mut task1, &mut handle1);
+    let _ = executor.spawn(&mut task2, &mut handle2);
     executor.run();
-    println!("Foo result: {:?}", handle1.val);
-    println!("Bar result: {:?}", handle2.val);
+
+    assert!(handle1.value.is_some_and(|v| v.is_ok_and(|s| s == "Hello")));
+    assert!(handle2.value.is_some_and(|v| v == 300u32));
 }

--- a/examples/simple2.rs
+++ b/examples/simple2.rs
@@ -1,0 +1,117 @@
+use core::fmt::Debug;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{ready, Context, Poll};
+use miniloop::executor::Executor;
+use miniloop::helpers::yield_me;
+use std::time::Duration;
+
+fn is_expired(start: u64, delay_s: u64) -> bool {
+    get_timestamp_sec() - start < delay_s
+}
+
+fn sleep(ms: u64) {
+    std::thread::sleep(Duration::from_millis(ms));
+}
+
+async fn foo() -> Result<String, ()> {
+    let now = get_timestamp_sec();
+
+    while is_expired(now, 10) {
+        yield_me().await;
+        sleep(100);
+    }
+
+    Ok("Hello".to_string())
+}
+
+async fn bar() -> u32 {
+    let now = get_timestamp_sec();
+
+    while is_expired(now, 2) {
+        yield_me().await;
+        sleep(100);
+    }
+
+    100u32 + 200u32
+}
+
+fn get_timestamp_sec() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn pending_print(task_name: &str) {
+    let now = get_timestamp_sec();
+    println!("{now}: Task {task_name} is pending. Waiting for the next tick...");
+}
+
+struct Runner<'a, T: Future> {
+    future: Pin<&'a mut T>,
+    handle: Option<&'a mut Handle<T::Output>>,
+}
+
+impl<'a, T: Future> Runner<'a, T> {
+    fn new(future: &'a mut T) -> (Self, Handle<T::Output>) {
+        let future = unsafe { Pin::new_unchecked(future) };
+        let handle = Handle { val: None };
+        let runner = Self {
+            future,
+            handle: None,
+        };
+
+        (runner, handle)
+    }
+
+    fn link_handle(&mut self, handle: &'a mut Handle<T::Output>) {
+        self.handle = Some(handle);
+    }
+}
+
+impl<T: Future> Future for Runner<'_, T>
+where
+    T::Output: Debug,
+{
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let res = ready!(self.as_mut().future.as_mut().poll(cx));
+
+        if let Some(handle) = self.handle.as_mut() {
+            handle.val = Some(res);
+        }
+
+        Poll::Ready(())
+    }
+}
+
+struct Handle<T> {
+    val: Option<T>,
+}
+
+macro_rules! bind {
+    ($e:expr) => {{
+        let _binding = async { $e().await };
+        _binding
+    }};
+}
+
+fn main() {
+    let mut executor = Executor::new();
+    executor.set_pending_callback(pending_print);
+
+    let mut binding1 = bind!(foo);
+    let (mut runner1, mut handle1) = Runner::new(&mut binding1);
+    runner1.link_handle(&mut handle1);
+    let _ = executor.spawn("foo", &mut runner1);
+    let mut binding2 = bind!(bar);
+    let (mut runner2, mut handle2) = Runner::new(&mut binding2);
+    runner2.link_handle(&mut handle2);
+    let _ = executor.spawn("bar", &mut runner2);
+
+    executor.run();
+    println!("Foo result: {:?}", handle1.val);
+    println!("Bar result: {:?}", handle2.val);
+}

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -130,11 +130,10 @@ impl<'a> Executor<'a> {
     /// # Errors
     ///
     /// * `NoFreeSlots` - if there is no free slots in the executor
-    pub fn spawn(
-        &mut self,
-        name: &'a str,
-        future: &'a mut impl Future<Output = ()>,
-    ) -> Result<(), Error> {
+    pub fn spawn<F>(&mut self, name: &'a str, future: &'a mut F) -> Result<(), Error>
+    where
+        F: Future<Output = ()> + 'a,
+    {
         if self.index >= self.tasks.len() {
             return Err(Error::NoFreeSlots);
         }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -77,7 +77,7 @@ impl<'a> Executor<'a> {
     /// The `#[must_use]` attribute indicates that the returned `Executor` instance should not
     /// be discarded.
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             tasks: [const { None }; TASK_ARRAY_SIZE],
             index: 0,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -11,31 +11,6 @@
 //!
 //! ## Examples
 //!
-//! ### Creating a New Executor
-//! ```rust
-//! # use miniloop::executor::Executor;
-//! let executor = Executor::new();
-//! ```
-//!
-//! ### Setting a Pending Callback
-//! ```rust
-//! # use miniloop::executor::Executor;
-//! let mut executor = Executor::new();
-//! executor.set_pending_callback(|task_name| {
-//!     println!("Task {} is pending", task_name);
-//! });
-//! ```
-//!
-//! ### Spawning a Task
-//! ```no_run
-//! # use miniloop::executor::Executor;
-//! # use miniloop::task::Task;
-//! let mut executor = Executor::new();
-//! let mut task = Task::new("task1", async { println!("Task executed"); });
-//! let mut handle = task.create_handle();
-//! executor.spawn(&mut task, &mut handle).expect("Failed to spawn task");
-//! ```
-//!
 //! ### Running the Executor
 //! ```no_run
 //! # use miniloop::executor::Executor;
@@ -101,14 +76,6 @@ impl<'a> Executor<'a> {
     ///
     /// The `#[must_use]` attribute indicates that the returned `Executor` instance should not
     /// be discarded.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use miniloop::executor::Executor;
-    ///
-    /// let executor = Executor::new();
-    /// ```
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -194,6 +161,10 @@ impl<'a> Executor<'a> {
     ///
     /// The method repeatedly polls each task in the tasks array. If a task completes, it is removed from the array.
     /// The function keeps running until all tasks are either completed or removed from the tasks array.
+    ///
+    /// <div class="warning">
+    /// That call does not return till all tasks are finished theirs execution.
+    /// </div>
     ///
     /// # Behavior
     ///

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -7,24 +7,27 @@
 //!
 //! ```no_run
 //! # use miniloop::executor::Executor;
+//! # use miniloop::task::Task;
 //! # use core::future::Future;
 //! use miniloop::helpers::yield_me;
 //! // Assume `some_future` is a mutable future reference
 //! let mut executor = Executor::new();
-//! let mut task1 = async {
+//! let mut task1 = Task::new("task1", async {
 //!     loop {
 //!         // computation
 //!         yield_me().await; // let to switch to another task
 //!     }
-//! };
-//! let mut task2 = async {
+//! });
+//! let mut handle1 = task1.create_handle();
+//! let mut task2 = Task::new("task2", async {
 //!     loop {
 //!         // computation
 //!         yield_me().await; // let to switch to another task
 //!     }
-//! };
-//! executor.spawn("task1", &mut task1).expect("Failed to spawn task");
-//! executor.spawn("task2", &mut task2).expect("Failed to spawn task");
+//! });
+//! let mut handle2 = task2.create_handle();
+//! executor.spawn(&mut task1, &mut handle1).expect("Failed to spawn task");
+//! executor.spawn(&mut task2, &mut handle2).expect("Failed to spawn task");
 //! executor.run();
 //! ```
 use core::default::Default;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,14 +31,16 @@
 //!
 //! ```rust,no_run
 //! use miniloop::executor::Executor;
+//! use miniloop::task::Task;
 //!
 //! let mut executor = Executor::new();
 //!
-//! let mut task = async {
+//! let mut task = Task::new("task", async {
 //!     println!("Hello, world!");
-//! };
+//! });
+//! let mut handle = task.create_handle();
 //!
-//! executor.spawn("task", &mut task).expect("Failed to spawn task");
+//! executor.spawn(&mut task, &mut handle).expect("Failed to spawn task");
 //! executor.run();
 //! ```
 //!
@@ -46,18 +48,22 @@
 //!
 //! ```rust,no_run
 //! use miniloop::executor::Executor;
+//! use miniloop::task::Task;
 //!
 //! let mut executor = Executor::new();
 //!
-//! let mut task1 = async {
+//! let mut task1 = Task::new("task1", async {
 //!     println!("Task 1 executed");
-//! };
-//! let mut task2 = async {
-//!     println!("Task 2 executed");
-//! };
+//! });
+//! let mut handle1 = task1.create_handle();
 //!
-//! executor.spawn("task1", &mut task1).expect("Failed to spawn task 1");
-//! executor.spawn("task2", &mut task2).expect("Failed to spawn task 2");
+//! let mut task2 = Task::new("task2", async {
+//!     println!("Task 2 executed");
+//! });
+//! let mut handle2 = task2.create_handle();
+//!
+//! executor.spawn(&mut task1, &mut handle1).expect("Failed to spawn task 1");
+//! executor.spawn(&mut task2, &mut handle2).expect("Failed to spawn task 2");
 //!
 //! executor.run();
 //! ```
@@ -78,15 +84,21 @@
 //! Happy learning!
 //!
 #![no_std]
+extern crate alloc;
+
 pub mod executor;
 pub mod helpers;
 pub mod task;
 
+pub(crate) mod sbox;
+
 #[cfg(test)]
 mod test {
     use super::executor::Executor;
-    use core::cell::Cell;
+    use super::task::Task;
+
     use core::future::Future;
+    use core::iter::zip;
     use core::pin::Pin;
     use core::task::{Context, Poll};
 
@@ -101,49 +113,58 @@ mod test {
     }
 
     impl Future for MyTestFuture {
-        type Output = ();
+        type Output = u8;
 
         fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
             self.get_mut().0 = true;
-            Poll::Ready(())
+            Poll::Ready(42u8)
         }
     }
 
     #[test]
     fn test_one_future() {
-        let mut called = Cell::new(false);
         let mut executor = Executor::new();
-        let mut task = async {
-            *called.get_mut() = true;
-        };
-
-        let _ = executor.spawn("task", &mut task);
-
+        let mut task = Task::new("my_test_task", MyTestFuture::default());
+        let mut handle = task.create_handle();
+        let result = executor.spawn(&mut task, &mut handle);
+        assert!(result.is_ok());
         executor.run();
-
-        assert!(called.take());
+        assert!(handle.value.is_some_and(|v| v == 42u8));
     }
 
     #[test]
     fn test_multiple_futures() {
-        let mut task_array = [const { MyTestFuture::default() }; TASK_ARRAY_SIZE];
+        let mut task_array =
+            [const { Task::new_nameless(MyTestFuture::default()) }; TASK_ARRAY_SIZE];
+        let mut handles = [(); TASK_ARRAY_SIZE].map(|()| task_array[0].create_handle());
         let mut executor = Executor::new();
 
-        for task in &mut task_array {
-            let _ = executor.spawn("", task);
+        for (task, handle) in zip(&mut task_array, &mut handles) {
+            let result = executor.spawn(task, handle);
+            assert!(result.is_ok(), "Failed to spawn task");
         }
 
+        // Run the executor
         executor.run();
-        assert!(task_array.iter().all(|task| task.0));
+
+        // Validate that all tasks completed with the expected return value
+        for handle in &handles {
+            assert!(
+                handle.value.is_some_and(|v| v == 42),
+                "Task did not complete with expected value"
+            );
+        }
     }
 
     #[test]
     fn test_schedule_too_many_tasks() {
-        let mut array = [const { MyTestFuture::default() }; TASK_ARRAY_SIZE + 1];
+        let mut task_array =
+            [const { Task::new_nameless(MyTestFuture::default()) }; TASK_ARRAY_SIZE + 1];
+        let mut handles = [(); TASK_ARRAY_SIZE].map(|()| task_array[0].create_handle());
         let mut executor = Executor::new();
 
-        for (i, element) in &mut array.iter_mut().enumerate() {
-            let result = executor.spawn("", element);
+        for (i, (task, handle)) in zip(&mut task_array, &mut handles).enumerate() {
+            let result = executor.spawn(task, handle);
 
             if i < TASK_ARRAY_SIZE {
                 assert!(result.is_ok());
@@ -151,5 +172,29 @@ mod test {
                 assert!(result.is_err());
             }
         }
+    }
+
+    #[test]
+    fn test_different_return_type_tasks() {
+        let mut task1 = Task::new("task1", async { 1u32 });
+        let mut handle1 = task1.create_handle();
+        let mut task2 = Task::new("task1", async {
+            if false {
+                return Err(());
+            }
+
+            Ok(2u32)
+        });
+        let mut handle2 = task2.create_handle();
+        let mut executor = Executor::new();
+
+        let result = executor.spawn(&mut task1, &mut handle1);
+        assert!(result.is_ok());
+        let result = executor.spawn(&mut task2, &mut handle2);
+        assert!(result.is_ok());
+        executor.run();
+
+        assert_eq!(handle1.value, Some(1u32));
+        assert_eq!(handle2.value, Some(Ok(2u32)));
     }
 }

--- a/src/sbox.rs
+++ b/src/sbox.rs
@@ -1,0 +1,79 @@
+//! # `StackBox` implementation
+//!
+//! A module for working with `StackBox`, a container designed to store pinned references to values
+//! on the stack.
+//!
+//! This module provides functionality for safely pinning values in place, which is essential for
+//! certain types such as `Future`s, generators, or other types that depend on stable memory
+//! addresses.
+//!
+//! The `StackBox` struct ensures that values are pinned in place on the stack, avoiding unnecessary
+//! heap allocation while maintaining safety and ensuring values cannot be moved out of the pinned
+//! context. Additionally, it provides a convenient type alias for working with stack-pinned
+//! `Future`s (`StackBoxFuture`).
+//!
+//! # Features
+//! - `StackBox` for safely wrapping and pinning stack-based values.
+//! - Type alias `StackBoxFuture` for stack-based pinned trait objects implementing `Future`.
+
+use crate::task::TaskFuture;
+
+use core::cell::OnceCell;
+use core::pin::Pin;
+
+/// A container for holding a pinned reference to a value on the stack.
+///
+/// The `StackBox` struct provides a way to safely pin a value in place on the stack.
+/// A pinned reference means that the value pointed to by the reference cannot be moved.
+/// This is important for certain types that rely on stable addresses, such as generators or futures.
+///
+/// # Type Parameters
+/// - `'a`: The lifetime of the reference to the stored value.
+/// - `T`: The type of the value to be stored. The type may be dynamically sized (`?Sized`).
+pub struct StackBox<'a, T: ?Sized> {
+    /// A `OnceCell` containing a pinned mutable reference to the stored value.
+    pub value: OnceCell<Pin<&'a mut T>>,
+}
+
+impl<T: ?Sized> Default for StackBox<'_, T> {
+    fn default() -> Self {
+        StackBox {
+            value: OnceCell::new(),
+        }
+    }
+}
+
+impl<'a, T: ?Sized> StackBox<'a, T> {
+    /// Creates a new `StackBox` containing a pinned reference to the provided value.
+    ///
+    /// # Arguments
+    /// - `value`: A mutable reference to the value to be stored. The reference must have the
+    ///   appropriate lifetime `'a`.
+    ///
+    /// # Returns
+    /// A `StackBox` containing a pinned mutable reference to the provided value.
+    ///
+    /// # Safety
+    /// This function uses `Pin::new_unchecked`, which is unsafe because it assumes
+    /// that the value being pinned will not move for the duration of the pin.
+    /// Ensure that the value cannot be moved out of the `StackBox`.
+    pub fn new(value: &'a mut T) -> Self {
+        let new_box = StackBox::default();
+        new_box
+            .value
+            .get_or_init(|| unsafe { Pin::new_unchecked(value) });
+
+        new_box
+    }
+}
+
+/// A type alias for a `StackBox` containing a `Future` trait object.
+///
+/// The `StackBoxFuture` type is a convenient way to create a stack-based pinned
+/// future. This allows futures to be stored and run on the stack rather than
+/// being allocated on the heap, which can be useful in certain performance-sensitive
+/// scenarios.
+///
+/// # Type Parameters
+/// - `'a`: The lifetime of the reference to the stored future.
+pub type StackBoxFuture<'a> = StackBox<'a, dyn TaskFuture + 'a>;


### PR DESCRIPTION
# Breaking Change

- Update `Executor` implementation to allow slightly different `Task` storing in order to allow result return from a supplied future